### PR TITLE
better has property name

### DIFF
--- a/profiles/prod.build.profile.js
+++ b/profiles/prod.build.profile.js
@@ -1,6 +1,6 @@
 /*jshint unused:false */
 var profile = {
     staticHasFeatures: {
-        'agrc-api-key': '"prod"'
+        'agrc-build': '"prod"'
     }
 };

--- a/profiles/stage.build.profile.js
+++ b/profiles/stage.build.profile.js
@@ -1,6 +1,6 @@
 /*jshint unused:false */
 var profile = {
     staticHasFeatures: {
-        'agrc-api-key': '"stage"'
+        'agrc-build': '"stage"'
     }
 };

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -3,7 +3,7 @@ define(['dojo/has', 'esri/config'], function (has, esriConfig) {
     // force api to use CORS on mapserv thus removing the test request on app load
     // e.g. http://mapserv.utah.gov/ArcGIS/rest/info?f=json
     esriConfig.defaults.io.corsEnabledServers.push('mapserv.utah.gov');
-    
+
     window.AGRC = {
         // errorLogger: ijit.modules.ErrorLogger
         errorLogger: null,
@@ -53,10 +53,10 @@ define(['dojo/has', 'esri/config'], function (has, esriConfig) {
         }
     };
 
-    if (has('agrc-api-key') === 'prod') {
+    if (has('agrc-build') === 'prod') {
         // mapserv.utah.gov
         window.AGRC.apiKey = 'AGRC-A94B063C533889';
-    } else if (has('agrc-api-key') === 'stage') {
+    } else if (has('agrc-build') === 'stage') {
         // test.mapserv.utah.gov
         window.AGRC.apiKey = 'AGRC-AC122FA9671436';
     } else {


### PR DESCRIPTION
This makes more sense when you are changing more than just the apiKey. For example:

```javascript
var apiKey;
if (has('agrc-build') === 'prod') {
    // mapserv.utah.gov
    apiKey = 'AGRC-A94B063C533889';
    domain = 'http://mapserv.utah.gov/';
} else if (has('agrc-build') === 'stage') {
    // test.mapserv.utah.gov
    apiKey = 'AGRC-AC122FA9671436';
    domain = '/';
} else {
    // localhost
    apiKey = 'AGRC-7F8F0DA6655711';
    domain = '/';
}
```

@steveoh Please review.