### PR TITLE
better AMD checker

### DIFF
--- a/src/app/tests/jasmineAMDErrorChecking.js
+++ b/src/app/tests/jasmineAMDErrorChecking.js
@@ -2,6 +2,8 @@ require(['dojo/domReady!'], function () {
     describe('AMD Loader', function () {
         it('dependencies loaded successfully', function (done) {
             var pause = 100;
+            var tries = 1;
+            var maxTries = 10;
 
             var hasProps = function (obj) {
                 for (var prop in obj) {
@@ -17,7 +19,13 @@ require(['dojo/domReady!'], function () {
                 if (hasProps(require.waiting)) {
                     // Keep checking until jasmine default timeout. 
                     // xstyle/css seems to make this take an extra few milliseconds.
-                    window.setTimeout(check, pause);
+                    if (tries < maxTries) {
+                        window.setTimeout(check, pause);
+                    } else {
+                        expect(require.waiting).toEqual({});
+                        done();
+                    }
+                    tries = tries + 1;
                 } else {
                     expect(require.waiting).toEqual({});
                     done();


### PR DESCRIPTION
This allows for the xstyle delay but also correctly reports the modules that failed to load.