### PR TITLE
use stylus resolve url

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -286,7 +286,8 @@ module.exports = function (grunt) {
         stylus: {
             main: {
                 options: {
-                    compress: false
+                    compress: false,
+                    'resolve url': true
                 },
                 files: [{
                     expand: true,


### PR DESCRIPTION
By default Stylus don’t resolve the urls in imported .styl files, so if you’d happen to have a foo.styl with @import "bar/bar.styl" which would have url("baz.png"), it would be url("baz.png") too in a resulting CSS.

But you can alter this behavior by using --resolve-url (or just -r) option to get url("bar/baz.png") in your resulting CSS.