### PR TITLE
move packages from userConfig.packages to just packages

### DIFF
--- a/profiles/build.profile.js
+++ b/profiles/build.profile.js
@@ -30,7 +30,7 @@ var profile = {
             exclude: ['dojo/dojo']
         }
     },
-    packages: [{
+    packages: ['app','dijit','dojox','agrc','ijit','esri','layer-selector', {
         name: 'proj4',
         trees: [
           // don't bother with .hidden, tests, min, src, and templates
@@ -77,9 +77,6 @@ var profile = {
     },
     plugins: {
         'xstyle/css': 'xstyle/build/amd-css'
-    },
-    userConfig: {
-        packages: ['app', 'dijit', 'dojox', 'agrc', 'ijit', 'esri', 'layer-selector']
     },
     map: {
         '*': {


### PR DESCRIPTION
After trouble shooting my build issues and some discussion with @steveoh, I fixed my issue and propose it back with an explanation.

If my understanding of why `userConfig: { packages [...] }` was added to this build profile is the html templates where not being added to the build layer. The reason they were not was because the packages were not included in `profile.packages`. AMD loading of JS modules is all fine and dandy because package definitions have been defined in https://github.com/agrc/AGRCJavaScriptProjectBoilerPlate/blob/master/src/app/packages.js. This is not the case with resolving paths with `dojo/text!`. The packages must be in `profile.packages` for the build text plugin to resolve relative paths. Even if you would have hard coded the templates into the build layer, `dojo/text!` would still not have resolved the paths to the build layer and would have requested the html files.

I'm not sure why `userConfig` exists but it essentially augments the profile at build time. I suspect to add properties through some other avenue other than the profile. `userConfig.packages` just ended up in `profile.packages` (actually some build processes ran twice). You might as well just wrap all your profile props in `userConfig`...just kidding. :)

It's six of one; half dozen of the the other. Just less code and less work for the build system.